### PR TITLE
Update blacklists & whitelist for some files in layout.

### DIFF
--- a/modeline.py
+++ b/modeline.py
@@ -57,6 +57,7 @@ dirBlackList = [
     'dom/system/gonk/android_audio/',
     'dom/webbrowserpersist/',
     'dom/webauthn/cbor-cpp/src/',
+    'layout/tables/',
   ]
 
 # Don't try to fix these files.
@@ -103,6 +104,7 @@ fileBlackList = [
     'ipc/glue/MessageLink.h',
     'ipc/glue/MessageLink.cpp',
     'ipc/glue/ProtocolUtils.h',
+    'layout/base/nsCounterManager.h',
   ]
 
 # Don't complain about apparently invalid indentation for these files.
@@ -176,6 +178,10 @@ indentWhiteList = [
     'ipc/chromium/src/chrome/common/notification_type.h',
     'ipc/chromium/src/chrome/common/result_codes.h',
     'ipc/glue/Transport_win.h',
+    'layout/base/nsCaret.h',
+    'layout/base/nsStyleChangeList.cpp',
+    'layout/base/RestyleManagerInlines.h',
+    'layout/build/nsContentDLF.h',
   ]
 
 


### PR DESCRIPTION
layout/tables/ has lots of files with 4-space indentation -- hence,
blacklisting that whole directory.