### PR TITLE
Update blacklists & whitelist for more files in layout.

### DIFF
--- a/modeline.py
+++ b/modeline.py
@@ -58,6 +58,7 @@ dirBlackList = [
     'dom/webbrowserpersist/',
     'dom/webauthn/cbor-cpp/src/',
     'layout/tables/',
+    'layout/tools/layout-debug/src/'
   ]
 
 # Don't try to fix these files.
@@ -105,6 +106,12 @@ fileBlackList = [
     'ipc/glue/MessageLink.cpp',
     'ipc/glue/ProtocolUtils.h',
     'layout/base/nsCounterManager.h',
+    'layout/generic/nsIntervalSet.h',
+    'layout/generic/nsIntervalSet.cpp',
+    'layout/style/nsCSSPropertyIDSet.h',
+    'layout/style/test/ParseCSS.cpp',
+    'layout/style/test/ListCSSProperties.cpp',
+    'layout/xul/nsTextBoxFrame.cpp',
   ]
 
 # Don't complain about apparently invalid indentation for these files.
@@ -182,6 +189,20 @@ indentWhiteList = [
     'layout/base/nsStyleChangeList.cpp',
     'layout/base/RestyleManagerInlines.h',
     'layout/build/nsContentDLF.h',
+    'layout/generic/nsColumnSetFrame.h',
+    'layout/style/nsCSSParser.h',
+    'layout/style/nsCSSPropAliasList.h',
+    'layout/style/nsCSSPropList.h',
+    'layout/style/nsCSSPseudoClassList.h',
+    'layout/style/nsMediaFeatures.h',
+    'layout/style/nsStyleTransformMatrix.h',
+    'layout/style/ServoBindingList.h',
+    'layout/style/StyleSetHandle.h',
+    'layout/xul/nsSplitterFrame.h',
+    'layout/xul/nsTitleBarFrame.cpp',
+    'layout/xul/PopupBoxObject.h',
+    'layout/xul/grid/nsGridRowLayout.cpp',
+    'layout/xul/tree/nsTreeContentView.h',
   ]
 
 


### PR DESCRIPTION
With these tweaks and some local fixes that I'll land shortly on
mozilla-central, this modeline.py script can successfully process all of
/layout.